### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wiz_light
-A Home assistant integration for Phillips WiZ Light bulbs
+A Home assistant integration for WiZ Light bulbs
 
 This is a fork of https://github.com/sbidy/wiz_light/ and fixes several issues with the component. Please note that once these two PRs are merged you should use the original component as I do not aim at maintaining this one: (https://github.com/sbidy/wiz_light/pull/9, https://github.com/sbidy/pywizlight/pull/2)
 


### PR DESCRIPTION
first of all it is written with only one l, secondly is wiz afaik an independend company not together with philips (maybe philips has produced wiz bulbs in the past but i dont think tho anymore reason is that they have now there own smart lights system caled hue)